### PR TITLE
Add Makefile to build image

### DIFF
--- a/.github/workflows/quay.yml
+++ b/.github/workflows/quay.yml
@@ -1,0 +1,29 @@
+name: Quay
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-[0-9]+"
+  workflow_dispatch:
+
+env:
+  REGISTRY: quay.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Registry login
+        run: echo "${{ secrets.QUAY_TOKEN }}" | podman login ${REGISTRY} -u ${{ secrets.QUAY_USER }} --password-stdin
+
+      - name: Build and Push the index image
+        run: |
+          ORG=${GITHUB_REPOSITORY%/*}
+          TAG=$(git tag --points-at HEAD)
+          VERSION=${TAG/v/}
+          make all ORG=${ORG} VERSION=${VERSION}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased] -
+
+## [0.2.6] - 2021-07-01
+
+- Add support to disconnected environments (SHA2 digest)
+- trex-operator:v0.2.6
+- testpmd-operator:v0.2.6
+- testpmd-lb-operator:v0.2.5
+- cnf-app-mac-operator:v0.2.6

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ OPM_REPO       ?= https://github.com/operator-framework/operator-registry
 OS             := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH           := $(shell uname -m | sed 's/x86_64/amd64/')
 OPERATORS_LIST := operators.cfg
+SHELL          := /bin/bash
 
 all: index-build index-push
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+VERSION        := 0.2.5
+TAG            := v$(VERSION)
+REGISTRY       ?= quay.io
+ORG            ?= rh-nfv-int
+CONTAINER_CLI  ?= podman
+CLUSTER_CLI    ?= oc
+INDEX_NAME     := nfv-example-cnf-catalog
+INDEX_IMG      ?= $(REGISTRY)/$(ORG)/$(INDEX_NAME):$(TAG)
+OPM_VERSION    ?= latest
+OPM_REPO       ?= https://github.com/operator-framework/operator-registry
+OS             := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH           := $(shell uname -m | sed 's/x86_64/amd64/')
+OPERATORS_LIST := operators.cfg
+
+all: index-build index-push
+
+# Build the index image
+index-build: opm
+	@{ \
+	set -e ;\
+	source ./$(OPERATORS_LIST) ;\
+	BUNDLES_DIGESTS=() ;\
+	for OPERATOR in $${OPERATORS[@]}; do \
+    	operator_bundle=$${OPERATOR/:*}-bundle ;\
+    	operator_version=$${OPERATOR/*:} ;\
+    	operator_digest=$$(skopeo inspect docker://$(REGISTRY)/$(ORG)/$${operator_bundle}:$${operator_version} | jq -r '.Digest') ;\
+	BUNDLES_DIGESTS+=($(REGISTRY)/$(ORG)/$${operator_bundle}@$${operator_digest}) ;\
+	done ;\
+	$(OPM) index add --bundles $${BUNDLES_DIGESTS[@]} --tag $(INDEX_IMG) ;\
+	}
+
+# Push the index image
+index-push:
+	$(CONTAINER_CLI) push $(INDEX_IMG)
+
+# Installs opm if is not available
+.PHONY: opm
+OPM = $(shell pwd)/bin/opm
+opm:
+ifeq (,$(wildcard $(OPM)))
+ifeq (,$(shell which opm 2>/dev/null))
+	@{ \
+	set -e ;\
+	mkdir -p $(dir $(OPM)) ;\
+	OPM_TAG=v$(OPM_VERSION) ;\
+	if [[ $(OPM_VERSION) == "latest" ]]; then \
+	OPM_TAG=$$(curl -sI $(OPM_REPO)/releases/latest | awk '/^location:/ {print $$2}' | xargs basename | tr -d '\r') ;\
+	fi ;\
+	curl -sLo $(OPM) $(OPM_REPO)/releases/download/$${OPM_TAG}/$(OS)-$(ARCH)-opm ;\
+	chmod u+x $(OPM) ;\
+	}
+else
+OPM=$(shell which opm)
+endif
+endif

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION        := 0.2.5
+VERSION        := 0.2.6
 TAG            := v$(VERSION)
 REGISTRY       ?= quay.io
 ORG            ?= rh-nfv-int

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # nfv-example-cnf-index
 
+This repository builds an index image that includes the [operators](https://github.com/rh-nfv-int/?q=operator&type=&language=&sort=) used by the [example-cnf](https://github.com/rh-nfv-int/nfv-example-cnf-deploy).
 
+The [CHANGELOG](./CHANGELOG.md) includes the information about the version of the image as well as the operators and their versions included in the image.

--- a/operators.cfg
+++ b/operators.cfg
@@ -1,0 +1,11 @@
+# This file is used to define the list of operators and their versions
+# that will be included in the index image via Makefile.
+# The list of operators is used to obtain the corresponding bundle image
+# and its digest to support disconnected environments.
+
+OPERATORS=(
+    trex-operator:v0.2.6
+    testpmd-operator:v0.2.6
+    testpmd-lb-operator:v0.2.5
+    cnf-app-mac-operator:v0.2.6
+)


### PR DESCRIPTION
- Adding a file with the list of operators to include in the index image
- Adding the GH Action workflow to build and publish the image on release tag
- Creates an image build that supports disconnected environments