### PR TITLE
Update container url to use org name

### DIFF
--- a/.github/workflows/quay.yml
+++ b/.github/workflows/quay.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Add component to DCI (distributed-ci.io)
         run: |
+          ORG=${GITHUB_REPOSITORY%/*}
           REPO_NAME=${GITHUB_REPOSITORY/*\/}
           INDEX_NAME=nfv-example-cnf-catalog
           pip install dciclient
@@ -42,7 +43,7 @@ jobs:
           NAME="${TAG}"
           CANONICAL_NAME="${REPO_NAME}:${TAG}"
           TYPE="nfv-example-cnf-index"
-          CONTAINER_URL="${REGISTRY}/${REPO_NAME}/${INDEX_NAME}"
+          CONTAINER_URL="${REGISTRY}/${ORG}/${INDEX_NAME}"
           DATA='{"url": "'${CONTAINER_URL}'"}'
           TEAM_ID=$( dcictl --format json team-list | jq -r '.teams[]|.id' )
           for ocp_version in ${OCP_VERSIONS}; do


### PR DESCRIPTION
URL name must be: `${REGISTRY}/${ORG}/${INDEX_NAME}` where
REGISTRY=quay.io
ORG=rh-nfv-int
INDEX_NAME=nfv-example-cnf-catalog

As the image is in quay.io/rh-nfv-int/nfv-example-cnf-catalog