### PR TITLE
Update index to use operators version 0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
+## [0.2.9] - 2021-08-25
+
+- Use operator versions 0.2.9
+
+## [0.2.8] - 2021-08-08
+
+- Use operator versions to 0.2.8
 ## [0.2.7] - 2021-07-28
 
 - [testpmd-lb-operator:v0.2.6](https://github.com/rh-nfv-int/testpmd-lb-operator/blob/master/CHANGELOG.md#026---2021-07-28)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION        := 0.2.8
+VERSION        := 0.2.9
 TAG            := v$(VERSION)
 REGISTRY       ?= quay.io
 ORG            ?= rh-nfv-int

--- a/operators.cfg
+++ b/operators.cfg
@@ -4,8 +4,8 @@
 # and its digest to support disconnected environments.
 
 OPERATORS=(
-    trex-operator:v0.2.8
-    testpmd-operator:v0.2.8
-    testpmd-lb-operator:v0.2.8
-    cnf-app-mac-operator:v0.2.8
+    trex-operator:v0.2.9
+    testpmd-operator:v0.2.9
+    testpmd-lb-operator:v0.2.9
+    cnf-app-mac-operator:v0.2.9
 )


### PR DESCRIPTION
- trex-operator:v0.2.9
- testpmd-operator:v0.2.9
- testpmd-lb-operator:v0.2.9
- cnf-app-mac-operator:v0.2.9