### PR TITLE
Add 4.10 OCP version

### DIFF
--- a/.github/workflows/quay.yml
+++ b/.github/workflows/quay.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   REGISTRY: quay.io
-  OCP_VERSIONS: "4.5 4.6 4.7 4.8 4.9"
+  OCP_VERSIONS: "4.5 4.6 4.7 4.8 4.9 4.10"
 
 jobs:
   build:


### PR DESCRIPTION
Adds 4.10 to the list of topics to use when creating example-cnf index components