### PR TITLE
Pin OPM version to avoid FBC issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ CONTAINER_CLI  ?= podman
 CLUSTER_CLI    ?= oc
 INDEX_NAME     := nfv-example-cnf-catalog
 INDEX_IMG      ?= $(REGISTRY)/$(ORG)/$(INDEX_NAME):$(TAG)
-OPM_VERSION    ?= latest
+# Don't use latest until FBC has been sorted out
+OPM_VERSION    ?= 1.19.5
 OPM_REPO       ?= https://github.com/operator-framework/operator-registry
 OS             := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH           := $(shell uname -m | sed 's/x86_64/amd64/')


### PR DESCRIPTION
- Using v1.19 we avoid the issue of FBC

```
$ make index-build
$ podman run -p50051:50051 -d --rm quay.io/rh-nfv-int/nfv-example-cnf-catalog:v0.2.9
$ grpcurl -plaintext localhost:50051 api.Registry/ListBundles | jq .packageName
"cnf-app-mac-operator"
"testpmd-lb-operator"
"testpmd-operator"
"trex-operator"
```

cc: @tkrishtop