### PR TITLE
Build indices using the FBC format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ CLUSTER_CLI    ?= oc
 INDEX_NAME     := nfv-example-cnf-catalog
 INDEX_IMG      ?= $(REGISTRY)/$(ORG)/$(INDEX_NAME):$(TAG)
 BUILD_PATH     ?= ./build
-# Don't use latest until FBC has been sorted out
 OPM_VERSION    ?= latest
 OPM_REPO       ?= https://github.com/operator-framework/operator-registry
 OS             := $(shell uname -s | tr '[:upper:]' '[:lower:]')
@@ -37,7 +36,7 @@ index-build: opm
 		echo -e $${channel} >> $(BUILD_PATH)/$(INDEX_NAME)/index.yml ;\
 	done ;\
 	$(OPM) validate $(BUILD_PATH)/$(INDEX_NAME) ;\
-	podman build $(BUILD_PATH) -f $(BUILD_PATH)/$(INDEX_NAME).Dockerfile -t $(INDEX_IMG) ;\
+	BUILDAH_FORMAT=docker podman build $(BUILD_PATH) -f $(BUILD_PATH)/$(INDEX_NAME).Dockerfile -t $(INDEX_IMG) ;\
 	rm -rf $(BUILD_PATH) ;\
 	}
 

--- a/nfv-example-cnf-catalog.Dockerfile
+++ b/nfv-example-cnf-catalog.Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM registry.redhat.io/openshift4/ose-operator-registry:v4.9
+FROM quay.io/operator-framework/upstream-opm-builder:latest
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs"]

--- a/nfv-example-cnf-catalog.Dockerfile
+++ b/nfv-example-cnf-catalog.Dockerfile
@@ -1,0 +1,11 @@
+# The base image is expected to contain
+# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM registry.redhat.io/openshift4/ose-operator-registry:v4.9
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs"]
+# Copy declarative config root into image at /configs
+ADD nfv-example-cnf-catalog /configs
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs


### PR DESCRIPTION
- Building the index using FBC format. The "index add" command will be deprecated
- The change is transparent for OLM
- Confirmed that the new index has the proper packages 
- We may not need to bump the index tag

```
$ podman run -p50051:50051 -it quay.io/rh-nfv-int/nfv-example-cnf-catalog:v0.2.9    	
          	  	
          	
$ grpcurl -plaintext localhost:50051 api.Registry/ListPackages
{
  "name": "trex-operator"
}
{
  "name": "testpmd-operator"
}
{
  "name": "testpmd-lb-operator"
}
{
  "name": "cnf-app-mac-operator"
}
```

