### PR TITLE
Update OPM image and set expiration for image

### DIFF
--- a/nfv-example-cnf-catalog.Dockerfile
+++ b/nfv-example-cnf-catalog.Dockerfile
@@ -9,4 +9,3 @@ ADD nfv-example-cnf-catalog /configs
 # Set DC-specific label for the location of the DC root directory
 # in the image
 LABEL operators.operatorframework.io.index.configs.v1=/configs
-LABEL maintainer="Telco DCI team" quay.expires-after=5h

--- a/nfv-example-cnf-catalog.Dockerfile
+++ b/nfv-example-cnf-catalog.Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM quay.io/operator-framework/upstream-opm-builder:latest
+FROM quay.io/operator-framework/opm:latest
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs"]
@@ -9,3 +9,4 @@ ADD nfv-example-cnf-catalog /configs
 # Set DC-specific label for the location of the DC root directory
 # in the image
 LABEL operators.operatorframework.io.index.configs.v1=/configs
+LABEL maintainer="Telco DCI team" quay.expires-after=5h


### PR DESCRIPTION
- This new images is smaller than the current one and we have tested it out on other places without issues
- Adding a label to make the tag expire