### PR TITLE
Use v1 version of the events API for trex-operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] -
 
+## [0.3.2] - 2023-02-01
+
+- Rebuild using a new trex-operator that uses the v1 version of the events API
+
 ## [0.3.1] - 2022-07-07
 
 - Rebuild to create DCI components for the upcoming release OCP 4.12

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION        := 0.3.1
+VERSION        := 0.3.2
 TAG            := v$(VERSION)
 REGISTRY       ?= quay.io
 ORG            ?= rh-nfv-int
@@ -34,12 +34,14 @@ index-build: opm
 		operator_manifest=$$(skopeo inspect docker://$(REGISTRY)/$(ORG)/$${operator_bundle}:$${operator_version}) ;\
 		operator_digest=$$(jq -r '.Digest' <<< $${operator_manifest}) ;\
 		bundle_digest=$(REGISTRY)/$(ORG)/$${operator_bundle}@$${operator_digest} ;\
+		echo "operator = $${operator_name}, operator_digest = $${operator_digest}" ;\
 		default_channel=$$(jq -r '.Labels."operators.operatorframework.io.bundle.channel.default.v1"' <<< $${operator_manifest}) ;\
 		channel="---\nschema: olm.channel\npackage: $${operator_name}\nname: $${default_channel}\nentries:\n  - name: $${operator_name}.$${operator_version}" ;\
 		$(OPM) init $${operator_name} --default-channel=$${default_channel} --output=yaml >> $(BUILD_PATH)/$(INDEX_NAME)/index.yml ;\
 		$(OPM) render $${bundle_digest} --output=yaml >> $(BUILD_PATH)/$(INDEX_NAME)/index.yml ;\
 		echo -e $${channel} >> $(BUILD_PATH)/$(INDEX_NAME)/index.yml ;\
 	done ;\
+	echo "validating the catalog" ;\
 	$(OPM) validate $(BUILD_PATH)/$(INDEX_NAME) ;\
 	BUILDAH_FORMAT=docker podman build $(BUILD_PATH) -f $(BUILD_PATH)/$(INDEX_NAME).Dockerfile -t $(INDEX_IMG) ;\
 	rm -rf $(BUILD_PATH) ;\

--- a/operators.cfg
+++ b/operators.cfg
@@ -4,7 +4,7 @@
 # and its digest to support disconnected environments.
 
 OPERATORS=(
-    trex-operator:v0.2.9
+    trex-operator:v0.2.12
     testpmd-operator:v0.2.9
     testpmd-lb-operator:v0.2.9
     cnf-app-mac-operator:v0.2.9


### PR DESCRIPTION
PR number 3.
This pull request build new catalog that uses new [trex-operator](https://github.com/rh-nfv-int/trex-operator/pull/9) that uses new [container-app image](https://github.com/rh-nfv-int/trex-container-app/pull/2).

The change is tested on 4.7 - 4.13, here is the job for 4.12: https://www.distributed-ci.io/jobs/2b446378-c588-45e5-bf1d-902b407e2779/jobStates?sort=date
All the other links are in cilab-291.